### PR TITLE
message requeue

### DIFF
--- a/src/QueueMessage.js
+++ b/src/QueueMessage.js
@@ -4,6 +4,8 @@ class QueueMessage {
     this.data = data
     this.timeOut = timeOut
     this.attachments = new Map()
+    this.nacked = false
+    this.requeued = false
   }
 
   static fromJSON (jsonString) {
@@ -61,6 +63,16 @@ class QueueMessage {
     } else {
       throw new Error('Impossible to deserialize the message')
     }
+  }
+
+  requeue () {
+    this.requeued = true
+    this.nacked = true
+  }
+
+  reject () {
+    this.requeued = false
+    this.nacked = true
   }
 
   /**

--- a/src/RPCServer.js
+++ b/src/RPCServer.js
@@ -132,7 +132,7 @@ class RPCServer {
     }, timeoutMs)
 
     try {
-      const answer = await this._callback(request.data, request, response)
+      const answer = await this._callback(request.data, request, response, msg)
 
       clearTimeout(timer)
 

--- a/src/Subscriber.js
+++ b/src/Subscriber.js
@@ -136,12 +136,20 @@ class Subscriber {
     return Promise.resolve().then(() => {
       return this._callback(request.data, msg.properties, request)
     }).then(() => {
-      if (!timedOut) {
-        clearTimeout(timer)
-        this._ack(channel, msg)
-        if (msg.fields && msg.fields.redelivered && msg.fields.consumerTag) {
-          this._retryMap.delete(msg.fields.consumerTag)
-        }
+      clearTimeout(timer)
+
+      if (request.nacked) {
+        this._nack(channel, msg, request.requeued)
+        return
+      }
+
+      if (timedOut) {
+        return
+      }
+
+      this._ack(channel, msg)
+      if (msg.fields && msg.fields.redelivered && msg.fields.consumerTag) {
+        this._retryMap.delete(msg.fields.consumerTag)
       }
     }).catch((err) => {
       if (!timedOut) {

--- a/src/Subscriber.js
+++ b/src/Subscriber.js
@@ -134,7 +134,7 @@ class Subscriber {
     }, timeoutMs)
 
     return Promise.resolve().then(() => {
-      return this._callback(request.data, msg.properties, request)
+      return this._callback(request.data, msg.properties, request, msg)
     }).then(() => {
       clearTimeout(timer)
 


### PR DESCRIPTION
Adds the ability to use the `requeue` argument of RabbitMQ's `nack()` call.
See: [#nack(message, [allUpTo, [requeue]])](http://www.squaremobius.net/amqp.node/channel_api.html#channel_nack)

**Usage**

`RPCServer` and `Subscriber` callbacks can use the provided `requeue()` and `reject()` methods on the `QueueMessage` objects to indicate whether they want to reject or requeue the handled message.

The `RPCServer` class got extended with an internal `_nack()` method and got slightly refactored.