### PR TITLE
Log vhost at connect

### DIFF
--- a/src/QueueConnection.js
+++ b/src/QueueConnection.js
@@ -49,7 +49,7 @@ class QueueConnection extends EventEmitter {
 
     this._connectionPromise = this._connect(this._config.url, options).then((conn) => {
       const urlObject = new URL(this._activeConnectionUrl)
-      this._logger.info(`RabbitMQ connection established on '${urlObject.host}' host`)
+      this._logger.info(`RabbitMQ connection established on '${urlObject.host}' host. vhost: ${urlObject.pathname}`)
 
       conn.on('error', (err) => {
         if (err.message !== 'Connection closing') {


### PR DESCRIPTION
Logs vhost at connection established. It is helpful to see this in the logs when we use a single cluster with multiple vhosts.