### PR TITLE
Shuffle connection urls

### DIFF
--- a/src/QueueConfig.js
+++ b/src/QueueConfig.js
@@ -28,6 +28,8 @@ class QueueConfig {
       rpcQueueMaxSize = 100,
       logger = console,
 
+      shuffleUrls = false,
+
       // Queue & exchange options
       rpcClientAssertReplyQueueOptions = {},
       rpcClientExchangeOptions = {},
@@ -57,6 +59,8 @@ class QueueConfig {
     this.rpcTimeoutMs = rpcTimeoutMs
     this.rpcQueueMaxSize = rpcQueueMaxSize
     this.logger = logger
+
+    this.shuffleUrls = shuffleUrls
 
     // Queue & exchange options
     this.rpcClientAssertReplyQueueOptions = rpcClientAssertReplyQueueOptions

--- a/src/QueueConnection.js
+++ b/src/QueueConnection.js
@@ -108,6 +108,10 @@ class QueueConnection extends EventEmitter {
   }
 
   async _connectWithMultipleUrls (urls, options) {
+    if (this._config.shuffleUrls) {
+      urls = this.shuffleUrls(urls)
+    }
+
     for (const url of urls) {
       const connectionUrl = QueueConfig.urlStringToObject(url)
       try {
@@ -120,6 +124,11 @@ class QueueConnection extends EventEmitter {
     }
 
     throw new Error('RabbitMQ connection filed with multiple urls')
+  }
+
+  shuffleUrls (urls) {
+    // shuffle urls - try to connect to nodes in a random order
+    return [...urls].sort((a, b) => 0.5 - Math.random())
   }
 
   /**

--- a/test/QueueConnection.test.js
+++ b/test/QueueConnection.test.js
@@ -95,7 +95,7 @@ describe('QueueConnection', () => {
     assert.deepEqual(connection._activeConnectionConfig, QueueConfig.urlStringToObject(config.url))
   })
 
-  it('#shuffleUrls() really shuffles the received urls', async () => {
+  it('#shuffleUrls() really shuffles the received urls and QueueConnection can still connect to the correct url', async () => {
     const original = ['amqps://random-host:5671', config.url]
     const connection = new QueueConnection(copyConfig({
       url: original,
@@ -118,6 +118,9 @@ describe('QueueConnection', () => {
     // This test failing has a chance of 1 in 2^100 (==1,267,650,600,228,229,401,496,703,205,376)
     assert.isTrue(canDoDifferent, 'connect urls shuffle failed to create different order out of a 100 tries')
     assert.isTrue(canDoTheSame, 'connect urls shuffle failed to create same order out of a 100 tries')
+
+    await connection.connect()
+    assert.isNotNull(connection._connection)
   })
 
   it('#close() closes connection to RabbitMQ', async () => {

--- a/test/QueueConnection.test.js
+++ b/test/QueueConnection.test.js
@@ -96,12 +96,15 @@ describe('QueueConnection', () => {
   })
 
   it('#shuffleUrls() really shuffles the received urls', async () => {
-    const connection = new QueueConnection(copyConfig({}))
+    const original = ['amqps://random-host:5671', config.url]
+    const connection = new QueueConnection(copyConfig({
+      url: original,
+      shuffleUrls: true
+    }))
 
     let canDoTheSame = false
     let canDoDifferent = false
 
-    const original = ['amqps://random-host:5671', config.url]
     for (let i = 1; i <= 100 && !(canDoTheSame && canDoDifferent); i++) {
       const shuffled = connection.shuffleUrls(original)
 

--- a/test/QueueConnection.test.js
+++ b/test/QueueConnection.test.js
@@ -95,6 +95,28 @@ describe('QueueConnection', () => {
     assert.deepEqual(connection._activeConnectionConfig, QueueConfig.urlStringToObject(config.url))
   })
 
+  it('#shuffleUrls() really shuffles the received urls', async () => {
+    const connection = new QueueConnection(copyConfig({}))
+
+    let canDoTheSame = false
+    let canDoDifferent = false
+
+    const original = ['amqps://random-host:5671', config.url]
+    for (let i = 1; i <= 100 && !(canDoTheSame && canDoDifferent); i++) {
+      const shuffled = connection.shuffleUrls(original)
+
+      if (JSON.stringify(original) === JSON.stringify(shuffled)) {
+        canDoTheSame = true
+      } else {
+        canDoDifferent = true
+      }
+    }
+
+    // This test failing has a chance of 1 in 2^100 (==1,267,650,600,228,229,401,496,703,205,376)
+    assert.isTrue(canDoDifferent, 'connect urls shuffle failed to create different order out of a 100 tries')
+    assert.isTrue(canDoTheSame, 'connect urls shuffle failed to create same order out of a 100 tries')
+  })
+
   it('#close() closes connection to RabbitMQ', async () => {
     const connection = new QueueConnection(config)
     try {


### PR DESCRIPTION
## Summary

- Added option to shuffle connection urls before connecting.

> NOTE: This can be useful if you want your applications to connect to random nodes in a cluster while keeping the list of urls ordered and consistent across configurations.