### PR TITLE
remove payload the can contain sensitive data from logs

### DIFF
--- a/src/GatheringClient.js
+++ b/src/GatheringClient.js
@@ -58,7 +58,7 @@ class GatheringClient {
           } else if (reply.properties.type === 'reply') {
             this._handleGatheringResponse(reply)
           } else {
-            this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': UNKNOWN MESSAGE TYPE ON REPLY`, correlationId, reply)
+            this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': UNKNOWN MESSAGE TYPE ON REPLY`, correlationId, reply.properties)
           }
         } catch (err) {
           this._logger.error(`QUEUE GATHERING CLIENT: FAILED TO HANDLE MESSAGE ON '${this.name}'`, correlationId, err)
@@ -72,19 +72,19 @@ class GatheringClient {
 
   isValidReply (reply) {
     if (!reply) {
-      this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO REPLY`, reply)
+      this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO REPLY`)
       return false
     }
     if (!reply.properties) {
-      this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO PROPERTIES ON REPLY`, reply)
+      this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO PROPERTIES ON REPLY`)
       return false
     }
     if (!reply.properties.correlationId) {
-      this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO CORRELATION ID ON REPLY`, reply)
+      this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO CORRELATION ID ON REPLY`, reply.properties)
       return false
     }
     if (!reply.properties.type) {
-      this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO MESSAGE TYPE ON REPLY`, reply)
+      this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO MESSAGE TYPE ON REPLY`, reply.properties)
       return false
     }
 
@@ -235,7 +235,7 @@ class GatheringClient {
         resolve(replyContent.data)
       }
     } else {
-      this._logger.error('QUEUE GATHERING CLIENT: RECEIVED ERROR REPLY', this.name, correlationId, replyContent)
+      this._logger.error('QUEUE GATHERING CLIENT: RECEIVED ERROR REPLY', this.name, correlationId)
       reject(new Error(replyContent.data))
     }
   }
@@ -252,7 +252,7 @@ class GatheringClient {
 
     const replyMessage = QueueMessage.unserialize(reply.content)
     if (replyMessage.status === 'error') {
-      this._logger.error(`QUEUE GATHERING CLIENT: RECEIVED ERROR STATUS ON '${this.name}'`, correlationId, replyMessage.data)
+      this._logger.error(`QUEUE GATHERING CLIENT: RECEIVED ERROR STATUS ON '${this.name}'`, correlationId)
       this._correlationIdMap.delete(correlationId)
       reject(new Error(replyMessage.data))
       return

--- a/src/GatheringServer.js
+++ b/src/GatheringServer.js
@@ -237,7 +237,7 @@ class GatheringServer {
     try {
       request = QueueMessage.unserialize(msg.content)
       if (request.status !== 'ok') {
-        this._logger.error(`QUEUE GATHERING SERVER: MESSAGE NOT OK '${this.name}' ${correlationId}`, request)
+        this._logger.error(`QUEUE GATHERING SERVER: MESSAGE NOT OK '${this.name}' ${correlationId}`)
         this._sendStatus(channel, replyTo, correlationId, 'error', 'message not OK')
         this._nack(channel, msg)
         return { isValid: false }

--- a/src/GatheringServer.js
+++ b/src/GatheringServer.js
@@ -208,12 +208,12 @@ class GatheringServer {
       return false
     }
     if (!msg.properties.correlationId) {
-      this._logger.error(`QUEUE GATHERING SERVER: INVALID REQUEST ON '${this.name}': NO CORRELATION ID`, msg)
+      this._logger.error(`QUEUE GATHERING SERVER: INVALID REQUEST ON '${this.name}': NO CORRELATION ID`, msg.properties)
       this._nack(channel, msg)
       return false
     }
     if (!msg.properties.replyTo) {
-      this._logger.error(`QUEUE GATHERING SERVER: INVALID REQUEST ON '${this.name}': NO REPLY TO`, msg)
+      this._logger.error(`QUEUE GATHERING SERVER: INVALID REQUEST ON '${this.name}': NO REPLY TO`, msg.properties)
       this._nack(channel, msg)
       return false
     }
@@ -264,7 +264,7 @@ class GatheringServer {
    */
   _ack (ch, msg) {
     if (msg.acked) {
-      this._logger.error('trying to double ack', msg)
+      this._logger.error('trying to double ack', msg.properties)
       return
     }
     ch.ack(msg)
@@ -279,7 +279,7 @@ class GatheringServer {
    */
   _nack (channel, msg, requeue = false) {
     if (msg.acked) {
-      this._logger.error('trying to double nack', msg)
+      this._logger.error('trying to double nack', msg.properties)
       return
     }
     channel.nack(msg, false, requeue)

--- a/src/RPCClient.js
+++ b/src/RPCClient.js
@@ -197,7 +197,7 @@ class RPCClient {
     }
 
     if (!this._correlationIdMap.has(reply.properties.correlationId)) {
-      this._logger.warn('UNABLE TO MATCH RPC REPLY WITH MESSAGE SENT ON %s (possibly timed out)', this.name, reply)
+      this._logger.warn('UNABLE TO MATCH RPC REPLY WITH MESSAGE SENT ON %s (possibly timed out)', this.name, reply.properties)
       return
     }
 
@@ -214,7 +214,7 @@ class RPCClient {
         resolve(replyContent.data)
       }
     } else {
-      this._logger.error('RPC CLIENT GOT ERROR', this.name, reply.properties.correlationId, replyContent)
+      this._logger.error('RPC CLIENT GOT ERROR', this.name, reply.properties.correlationId)
       reject(replyContent.data)
     }
   }

--- a/src/RPCServer.js
+++ b/src/RPCServer.js
@@ -110,7 +110,7 @@ class RPCServer {
    */
   _ack (ch, msg) {
     if (msg.acked) {
-      this._logger.error('trying to double ack', msg)
+      this._logger.error('trying to double ack', msg.properties)
       return
     }
     ch.ack(msg)

--- a/src/RPCServer.js
+++ b/src/RPCServer.js
@@ -197,7 +197,7 @@ class RPCServer {
     const timeoutMs = typeof request.timeOut === 'number' ? request.timeOut : this._timeoutMs
     const timer = setTimeout(() => {
       timedOut = true
-      this._logger.error('RPCServer response timeout', this.name, request.data)
+      this._logger.error('RPCServer response timeout', this.name)
       this.handleResponseTimeout(ch, msg, request)
     }, timeoutMs)
 

--- a/src/Subscriber.js
+++ b/src/Subscriber.js
@@ -88,7 +88,7 @@ class Subscriber {
    */
   _ack (channel, msg) {
     if (msg.acked) {
-      this._logger.error('trying to double ack', msg)
+      this._logger.error('trying to double ack', msg.properties)
       return
     }
     channel.ack(msg)
@@ -102,7 +102,7 @@ class Subscriber {
    */
   _nack (channel, msg) {
     if (msg.acked) {
-      this._logger.error('trying to double nack', msg)
+      this._logger.error('trying to double nack', msg.properties)
       return
     }
     channel.nack(msg)
@@ -147,7 +147,7 @@ class Subscriber {
     }
 
     if (counter > this._maxRetry) {
-      this._logger.error('SUBSCRIBER TRIED TOO MANY TIMES', this.name, msg)
+      this._logger.error('SUBSCRIBER TRIED TOO MANY TIMES', this.name, msg.properties)
       this._retryMap.delete(consumerTag)
       return true
     }

--- a/src/Subscriber.js
+++ b/src/Subscriber.js
@@ -114,7 +114,7 @@ class Subscriber {
       const request = this.MessageModel.unserialize(msg.content, this.ContentSchema)
 
       if (request.status !== 'ok') {
-        this._logger.error('CANNOT GET QUEUE MESSAGE PARAMS', this.name, request)
+        this._logger.error('CANNOT GET QUEUE MESSAGE PARAMS', this.name)
         return null
       }
 
@@ -147,7 +147,7 @@ class Subscriber {
     }
 
     if (counter > this._maxRetry) {
-      this._logger.error('SUBSCRIBER TRIED TOO MANY TIMES', this.name, request, msg)
+      this._logger.error('SUBSCRIBER TRIED TOO MANY TIMES', this.name, msg)
       this._retryMap.delete(consumerTag)
       return true
     }
@@ -178,7 +178,7 @@ class Subscriber {
     const timeoutMs = typeof request.timeOut === 'number' ? request.timeOut : this._timeoutMs
     const timer = setTimeout(() => {
       timedOut = true
-      this._logger.error('Timeout in Subscriber', this.name, request.data)
+      this._logger.error('Timeout in Subscriber', this.name)
       this._nack(channel, msg)
     }, timeoutMs)
 


### PR DESCRIPTION
instead of logging request and message:
```
[2023-05-30 12:19:24.026] [ERROR] vuer - SUBSCRIBER TRIED TOO MANY TIMES kiosk-queue-document-scan QueueMessage {
  status: 'ok',
  data: {
    action: 'document:send:result',
    data: { ids: [Object], customerData: [Object] }
  },
  timeOut: 15000,
  attachments: Map(5) {
    'croppedInfra' => <Buffer 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52 00 00 06 87 00 00 04 26 08 00 00 00 00 d7 36 39 cd 00 00 00 09 70 48 59 73 00 00 4c e3 00 00 4c e3 01 ... 763478 more bytes>,
    'croppedUV' => <Buffer 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52 00 00 06 87 00 00 04 26 08 02 00 00 00 7d 3f f1 46 00 00 00 09 70 48 59 73 00 00 4c e3 00 00 4c e3 01 ... 1587218 more bytes>,
    'croppedWhite' => <Buffer 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52 00 00 06 87 00 00 04 26 08 02 00 00 00 7d 3f f1 46 00 00 00 09 70 48 59 73 00 00 4c e3 00 00 4c e3 01 ... 2312059 more bytes>,
    'eCardFace' => <Buffer 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52 00 00 00 f0 00 00 01 40 08 02 00 00 00 0d 8a 66 04 00 00 00 09 70 48 59 73 00 00 00 00 00 00 00 00 01 ... 89121 more bytes>,
    'eCardSignature' => <Buffer 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52 00 00 00 c5 00 00 00 28 08 02 00 00 00 c1 80 a9 fb 00 00 00 09 70 48 59 73 00 00 00 00 00 00 00 00 01 ... 5162 more bytes>
  },
  ContentSchema: Object [JSON] {}
} {
  fields: {
    consumerTag: 'amq.ctag-Dod_gzqmK962guMiSAo8Hw',
    deliveryTag: 1545793,
    redelivered: true,
    exchange: '',
    routingKey: 'kiosk-queue-document-scan'
  },
  properties: {
    contentType: undefined,
    contentEncoding: undefined,
    headers: {},
    deliveryMode: undefined,
    priority: undefined,
    correlationId: undefined,
    replyTo: undefined,
    expiration: undefined,
    messageId: undefined,
    timestamp: undefined,
    type: undefined,
    userId: undefined,
    appId: undefined,
    clusterId: undefined
  },
  content: <Buffer 2b 00 00 02 6d 7b 22 73 74 61 74 75 73 22 3a 22 6f 6b 22 2c 22 64 61 74 61 22 3a 7b 22 61 63 74 69 6f 6e 22 3a 22 64 6f 63 75 6d 65 6e 74 3a 73 65 6e ... 4757864 more bytes>
 ```

log message.properties:

```
[2023-06-01 13:29:59.873] [ERROR] vuer - SUBSCRIBER TRIED TOO MANY TIMES kiosk-queue-document-scan {
  contentType: undefined,
  contentEncoding: undefined,
  headers: {},
  deliveryMode: undefined,
  priority: undefined,
  correlationId: undefined,
  replyTo: undefined,
  expiration: undefined,
  messageId: undefined,
  timestamp: undefined,
  type: undefined,
  userId: undefined,
  appId: undefined,
  clusterId: undefined
}
```