### PR TITLE
FKITDEV-2352: fix jsdoc

### DIFF
--- a/src/Publisher.js
+++ b/src/Publisher.js
@@ -1,5 +1,11 @@
 const QueueMessage = require('./QueueMessage')
 
+/**
+ * @typedef {import('./QueueConnection')} QueueConnection
+ * @typedef {import('amqplib').ConfirmChannel} ConfirmChannel
+ * @typedef {import('amqplib').QueueMessage} QueueMessage
+ */
+
 class Publisher {
   /**
    * @param {QueueConnection} queueConnection
@@ -24,6 +30,7 @@ class Publisher {
     this._assertExchange = assertExchange === true
     this._assertExchangeOptions = Object.assign({ durable: true }, assertExchangeOptions)
 
+    /** @type {typeof QueueMessage} MessageModel - The class reference for the QueueMessage model. */
     this.MessageModel = MessageModel
     this.ContentSchema = ContentSchema
   }
@@ -31,8 +38,7 @@ class Publisher {
   /**
    * Overridden in queueClient to assertQueue instead of exchange
    *
-   * @param channel
-   * @returns {Promise}
+   * @param {ConfirmChannel} channel
    */
   assertExchangeOrQueue (channel) {
     if (this._assertExchange) {

--- a/src/QueueConnection.js
+++ b/src/QueueConnection.js
@@ -5,6 +5,7 @@ const EventEmitter = require('events')
 
 /**
  * @class QueueConnection
+ * @extends EventEmitter
  * */
 class QueueConnection extends EventEmitter {
   /**
@@ -26,7 +27,7 @@ class QueueConnection extends EventEmitter {
   }
 
   /**
-   * @return Promise<amqplib.Connection>
+   * @returns {Promise<import('amqplib').Connection>}
    * */
   async connect () {
     if (this._connection) {
@@ -155,7 +156,7 @@ class QueueConnection extends EventEmitter {
   }
 
   /**
-   * @return Promise<amqplib.ConfirmChannel>
+   * @returns {Promise<import('amqplib').ConfirmChannel>}
    * */
   async getChannel () {
     if (this._channel) {

--- a/src/RPCClient.js
+++ b/src/RPCClient.js
@@ -2,6 +2,11 @@ const { v4: uuid } = require('uuid')
 const QueueMessage = require('./QueueMessage')
 
 /**
+ * @typedef {import('./QueueConnection')} QueueConnection
+ * @typedef {import('./QueueMessage')} QueueMessage
+ */
+
+/**
  * A queue handler
  * @class RPCClient
  * */
@@ -27,6 +32,7 @@ class RPCClient {
       exchangeOptions = {}
     } = options
 
+    /** @type {QueueConnection} */
     this._connection = queueConnection
     this._logger = logger
     this.name = rpcName
@@ -41,7 +47,9 @@ class RPCClient {
 
     this._rpcQueueMaxSize = queueMaxSize
     this._rpcTimeoutMs = timeoutMs
+    /** @type {typeof QueueMessage} RequestMessageModel - The class reference for the QueueMessage model. */
     this.RequestMessageModel = RequestMessageModel
+    /** @type {typeof QueueMessage} ResponseMessageModel - The class reference for the QueueMessage model. */
     this.ResponseMessageModel = ResponseMessageModel
     this.RequestContentSchema = RequestContentSchema
     this.ResponseContentSchema = ResponseContentSchema
@@ -105,8 +113,9 @@ class RPCClient {
    * @param {Map} attachments
    * @param {Boolean} [resolveWithFullResponse=false]
    * @param {Object} sendOptions
-   * @return {Promise<QueueMessage|*>}
-   * */
+   * @returns {Promise<QueueMessage|*>}
+   * @throws {Error}
+   */
   async call (message, timeoutMs = null, attachments = null, resolveWithFullResponse = false, sendOptions = {}) {
     try {
       if (this._correlationIdMap.size > this._rpcQueueMaxSize) {


### PR DESCRIPTION
- use correct syntax and existing types

https://youtrack.techteamer.com/issue/FKITDEV-2352/MQ-JSDoc-kiegeszites



- ` * @typedef {import('./QueueConnection')} QueueConnection`
tipusdefinicio után oldódik fel az alábbi hivatkozás:   
`* @param {QueueConnection} queueConnection`

- @returns a helyes syntax

- typeof keyword-el adható meg osztály referencia

```
/** @type {typeof QueueMessage} ResponseMessageModel - The class reference for the QueueMessage model. */
    this.ResponseMessageModel = ResponseMessageModel
```