### PR TITLE
FKITDEV-2146: Fix the reconnecting

### DIFF
--- a/src/QueueConnection.js
+++ b/src/QueueConnection.js
@@ -149,11 +149,12 @@ class QueueConnection extends EventEmitter {
         if (!err.message.startsWith('Connection closed')) {
           throw err
         }
+      } finally {
+        // TODO: only empty connection if the error is not related to connection closure
+        this._connection = null
+        this._connectionPromise = null
       }
     }
-
-    this._connection = null
-    this._connectionPromise = null
   }
 
   /**

--- a/src/QueueConnection.js
+++ b/src/QueueConnection.js
@@ -146,7 +146,9 @@ class QueueConnection extends EventEmitter {
         await this._connection.close()
       } catch (err) {
         this._logger.error('RabbitMQ close connection failed', err)
-        throw err
+        if (!err.message.startsWith('Connection closed')) {
+          throw err
+        }
       }
     }
 

--- a/src/QueueConnection.js
+++ b/src/QueueConnection.js
@@ -54,7 +54,7 @@ class QueueConnection extends EventEmitter {
       return connection
     }).catch((err) => {
       this._logger.error('RabbitMQ connection failed', err)
-
+      this._connectionPromise = null
       throw err
     })
 

--- a/src/QueueConnection.js
+++ b/src/QueueConnection.js
@@ -149,12 +149,11 @@ class QueueConnection extends EventEmitter {
         if (!err.message.startsWith('Connection closed')) {
           throw err
         }
-      } finally {
-        // TODO: only empty connection if the error is not related to connection closure
-        this._connection = null
-        this._connectionPromise = null
       }
     }
+
+    this._connection = null
+    this._connectionPromise = null
   }
 
   /**

--- a/src/QueueManager.js
+++ b/src/QueueManager.js
@@ -56,6 +56,10 @@ class QueueManager {
       throw err
     }
 
+    if (!this.connection._connection) {
+      throw new Error('Failed to connect to queue server')
+    }
+
     try {
       for (const [, rpcServer] of this.rpcServers) {
         await rpcServer.initialize()

--- a/src/QueueManager.js
+++ b/src/QueueManager.js
@@ -56,10 +56,6 @@ class QueueManager {
       throw err
     }
 
-    if (!this.connection._connection) {
-      throw new Error('Failed to connect to queue server')
-    }
-
     try {
       for (const [, rpcServer] of this.rpcServers) {
         await rpcServer.initialize()

--- a/test/ConnectionPool.test.js
+++ b/test/ConnectionPool.test.js
@@ -107,6 +107,25 @@ describe('ConnectionPool', () => {
     })
   })
 
+  it('should reconnect if the connection is already closed', async () => {
+    const pool = new ConnectionPool()
+    pool.setLogger(logger)
+    pool.setupQueueManagers({
+      default: config
+    })
+    try {
+      await pool.connect()
+      const queueManager = pool.getConnection('default')
+      await queueManager.connection.close()
+      await pool.reconnect()
+
+      assert.isNotNull(queueManager.connection._connection)
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error)
+    }
+  })
+
   it('Should not reconnect to wrong config', (done) => {
     const pool = new ConnectionPool()
     pool.setLogger(logger)

--- a/test/QueueConnection.test.js
+++ b/test/QueueConnection.test.js
@@ -238,4 +238,29 @@ describe('QueueConnection', () => {
 
     assert.strictEqual(callbackCalled, false)
   })
+
+  it('#close() already closed connection should not throw error', async () => {
+    const connection = new QueueConnection(config)
+    try {
+      await connection.connect()
+    } catch (connectionConnectError) {
+      throw new Error(`connect() failed: ${connectionConnectError}`)
+    }
+
+    try {
+      await connection.close()
+    } catch (connectionCloseError) {
+      throw new Error(`close() failed: ${connectionCloseError}`)
+    }
+
+    try {
+      await connection.close()
+    } catch (connectionCloseError) {
+      throw new Error(`close() on already closed connection failed: ${connectionCloseError}`)
+    }
+
+    assert.strictEqual(connection._connection, null)
+    assert.strictEqual(connection._connectionPromise, null)
+    assert.doesNotThrow(connection.close, Error)
+  })
 })


### PR DESCRIPTION
### Summary:

- ignore already closed connection errors to support optional queue reconnection logic
- add tests cases for the reconnection logic

### References:

**YouTrack ticket(s):**

[FKITDEV-2146](https://youtrack.techteamer.com/issue/FKITDEV-2146/Raiffeisen-Ujabb-OSS-restart)

**Related PR(s):**

[OSS Pull Request](https://github.com/TechTeamer/vuer_oss/pull/4484)
