### PR TITLE
FKITDEV-3087: Update Travis jdk version for Sonar scanner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,6 @@ env:
 
 script:
   - yarn test
+  - export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+  - export PATH=$JAVA_HOME/bin:$PATH
   - sonar-scanner

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ addons:
   apt:
     packages:
       - rabbitmq-server
+      - openjdk-17-jdk
   sonarcloud:
     organization: techteamer
 


### PR DESCRIPTION
- install JDK 17 which is required for SonarQube: https://docs.sonarsource.com/sonarqube/10.1/requirements/prerequisites-and-overview/
- specify newly installed JDK 17 path